### PR TITLE
Remove parenthesis from id slugs

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,14 @@ const syntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const markdownIt = require('markdown-it');
 const markdownItAnchor = require('markdown-it-anchor');
 
+function slugify(s) {
+    return encodeURIComponent(
+        String(s).trim().toLowerCase()
+        .replace(/[\(\)]/g, '')
+        .replace(/\s+/g, '-')
+    );
+}
+
 module.exports = function(eleventyConfig) {
   const src = process.env.SLATEDIR || 'source';
   eleventyConfig.addPassthroughCopy(src+"/slate/css/*.css");
@@ -16,7 +24,9 @@ module.exports = function(eleventyConfig) {
       html: true,
       linkify: true,
       typographer: true
-    }).use(markdownItAnchor, {})
+    }).use(markdownItAnchor, {
+        slugify: slugify,
+    })
   );
 };
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -25,8 +25,7 @@ module.exports = function(eleventyConfig) {
       linkify: true,
       typographer: true
     }).use(markdownItAnchor, {
-        slugify: slugify,
+        slugify: slugify
     })
   );
 };
-


### PR DESCRIPTION
Two small changes.

* Remove any parenthesis from the generated slugs
* Add markdown-include, so that other Markdown pages can be included from the index (and other pages, too!) by using this syntax:
```
!!!include(notice.api-key.md)!!!
```