### PR TITLE
Move from slash division to math.div()

### DIFF
--- a/source/slate/css/screen.scss
+++ b/source/slate/css/screen.scss
@@ -213,7 +213,7 @@ html, body {
 #nav-button {
   span {
     display: block;
-    $side-pad: $main-padding / 2 - 8px;
+    $side-pad: math.div($main-padding,2) - 8px;
     padding: $side-pad $side-pad $side-pad;
     background-color: rgba($main-bg, 0.7);
     transform-origin: 0 0;

--- a/source/slate/css/screen.scss
+++ b/source/slate/css/screen.scss
@@ -1,4 +1,5 @@
 @charset "utf-8";
+@use 'sass:math';
 @import 'normalize';
 @import 'variables';
 @import 'icon-font';


### PR DESCRIPTION
  Deprecation Warning: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
  
  Recommendation: math.div($main-padding, 2)
  
  More info and automated migrator: https://sass-lang.com/d/slash-div
  
      ╷
  216 │     $side-pad: $main-padding / 2 - 8px;
      │                ^^^^^^^^^^^^^^^^^
      ╵
      source\slate\css\screen.scss 216:16  root stylesheet
  
![image](https://user-images.githubusercontent.com/5055400/152654990-1aca298f-87cd-4b54-bf4a-7a190858bb6f.png)
